### PR TITLE
🔧 fix: correct symlink direction in HashMap and loop variables

### DIFF
--- a/src/services/init_service.rs
+++ b/src/services/init_service.rs
@@ -227,7 +227,7 @@ mod tests {
 
     fn create_test_config() -> DotfConfig {
         DotfConfig {
-            symlinks: HashMap::from([("~/.vimrc".to_string(), ".vimrc".to_string())]),
+            symlinks: HashMap::from([(".vimrc".to_string(), "~/.vimrc".to_string())]),
             scripts: ScriptsConfig::default(),
             platform: PlatformConfig::default(),
         }

--- a/src/services/install_service.rs
+++ b/src/services/install_service.rs
@@ -319,7 +319,7 @@ impl<F: FileSystem + Clone, S: ScriptExecutor, P: Prompt> InstallService<F, S, P
         let mut operations = Vec::new();
         let repo_path = self.filesystem.dotf_repo_path();
 
-        for (target, source) in symlinks {
+        for (source, target) in symlinks {
             // Expand target path (handle ~)
             let expanded_target = if target.starts_with("~/") {
                 let home = dirs::home_dir().ok_or_else(|| {
@@ -411,8 +411,8 @@ mod tests {
 
     fn create_test_config() -> DotfConfig {
         let mut symlinks = HashMap::new();
-        symlinks.insert("~/.vimrc".to_string(), ".vimrc".to_string());
-        symlinks.insert("~/.bashrc".to_string(), ".bashrc".to_string());
+        symlinks.insert(".vimrc".to_string(), "~/.vimrc".to_string());
+        symlinks.insert(".bashrc".to_string(), "~/.bashrc".to_string());
 
         let mut custom_scripts = HashMap::new();
         custom_scripts.insert("setup-vim".to_string(), "scripts/setup-vim.sh".to_string());

--- a/src/services/status_service.rs
+++ b/src/services/status_service.rs
@@ -359,7 +359,7 @@ impl<R: Repository, F: FileSystem + Clone> StatusService<R, F> {
         let mut operations = Vec::new();
         let repo_path = self.filesystem.dotf_repo_path();
 
-        for (target, source) in symlinks {
+        for (source, target) in symlinks {
             // Expand target path (handle ~)
             let expanded_target = if target.starts_with("~/") {
                 let home = dirs::home_dir().ok_or_else(|| {


### PR DESCRIPTION
## Summary
Fix symlink configuration to match README specification where symlinks are defined as "Source (in repo) -> Target (on system)".

## Problem
The symlink handling code was using inconsistent direction:
- HashMap was using `(target, source)` format
- Loop variables were `(target, source)` instead of `(source, target)`
- This contradicted the README documentation and dotf.toml specification

## Changes
- ✅ Updated HashMap structure from `(target, source)` to `(source, target)`
- ✅ Fixed loop variables in `install_service.rs` and `status_service.rs`
- ✅ Corrected test configurations in `init_service.rs`
- ✅ All tests pass
- ✅ Release build successful

## Test Plan
- [x] `cargo test` - All 87 tests pass
- [x] `cargo build --release` - Successful compilation
- [x] Symlink logic now matches README documentation format

## Files Changed
- `src/services/init_service.rs` - Test configuration fix
- `src/services/install_service.rs` - Loop variables and test data
- `src/services/status_service.rs` - Loop variables

Fixes symlink direction inconsistency to align with documented specification.

🤖 Generated with [Claude Code](https://claude.ai/code)